### PR TITLE
Update color schema

### DIFF
--- a/config
+++ b/config
@@ -1,12 +1,12 @@
 background-color=#282a36
-text-color=#44475a
+text-color=#f8f8f2
 border-color=#282a36
 
 [urgency=low]
-border-color=#282a36
+border-color=#8be9fd
 
 [urgency=normal]
-border-color=#f1fa8c
+border-color=#6272a4
 
 [urgency=high]
 border-color=#ff5555


### PR DESCRIPTION
This PR improves the color schema for Mako notifications. The current one doesn't reflect what the repo shows in the README.md file.

This is an example with urgency levels low, normal and critical:
![2022-04-25_17-19-22](https://user-images.githubusercontent.com/8699850/165168234-084920fb-6b2c-4b7d-8a4f-8c5cea66907c.png)
